### PR TITLE
Working function for create_account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# near-api-rs
+# NEAR Rust API
+
+Rust library to interact with NEAR Protocol via RPC API. Inspired by [NEAR API JS](https://github.com/near/near-api-js)
+

--- a/accounts/Cargo.toml
+++ b/accounts/Cargo.toml
@@ -10,4 +10,13 @@ near-crypto = "0.20.0"
 near-primitives = "0.20.0"
 providers = {path ="../providers"}
 transactions = {path ="../transactions"}
+near-jsonrpc-primitives = "0.20.0"
+near-jsonrpc-client = "0.8.0"
+tokio = { version = "1", features = ["full"] }
+serde_json = "1.0.85"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
+env_logger = "0.10.0"
+reqwest = { version = "0.11.12", features = ["json"], default-features = false }
 

--- a/accounts/README.md
+++ b/accounts/README.md
@@ -1,6 +1,6 @@
 ## Testing
 
-### Run the below command to run the create_account example:
+### Run the below command to run the create_account example. FYI, it helps you create subaccounts on the signer id and not accounts directly on near or testnet namespace.
 ```
 cargo run --example create_account
 ```

--- a/accounts/README.md
+++ b/accounts/README.md
@@ -1,0 +1,6 @@
+## Testing
+
+### Run the below command to run the create_account example:
+```
+cargo run --example create_account
+```

--- a/accounts/examples/create_account.rs
+++ b/accounts/examples/create_account.rs
@@ -1,0 +1,35 @@
+use providers::Provider;
+use providers::JsonRpcProvider;
+use std::sync::Arc;
+use near_crypto::InMemorySigner;
+use near_primitives::types::Balance;
+use near_crypto::{Signer};
+use accounts::Account;
+mod utils;
+use near_primitives::types::AccountId;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let signer_account_id: AccountId = utils::input("Enter the signer Account ID: ")?.parse()?;
+    let signer_secret_key = utils::input("Enter the signer's private key: ")?.parse()?;
+    let new_account_id = utils::input("Enter the signer's private key: ")?.parse()?;
+    let signer = InMemorySigner::from_secret_key(signer_account_id.clone(), signer_secret_key);
+        
+    // Amount to transfer to the new account
+    let amount: Balance = 10_000_000_000_000_000_000_000; // Example amount in yoctoNEAR
+
+    let new_key_pair = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
+    let provider = Arc::new(JsonRpcProvider::new("https://rpc.testnet.near.org"));
+    let signer = Arc::new(signer);
+
+    let account = Account::new(signer_account_id, signer, provider);
+    // Call create_account
+    let result = account.create_account(new_account_id, new_key_pair.public_key(), amount).await;
+
+
+    println!("response: {:#?}", result);
+
+    Ok(())
+}

--- a/accounts/examples/create_account.rs
+++ b/accounts/examples/create_account.rs
@@ -31,5 +31,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("response: {:#?}", result);
 
+    println!("=============================================================");
+    println!("New Account ID: {}", new_account_id);
+    println!("    Secret Key: {}", new_key_pair);
+    println!("    Public Key: {}", new_key_pair.public_key());
+    println!("       Deposit: {}", amount);
+    println!("-------------------------------------------------------------");
+
     Ok(())
 }

--- a/accounts/examples/utils.rs
+++ b/accounts/examples/utils.rs
@@ -1,0 +1,87 @@
+#![allow(unused)]
+
+use near_jsonrpc_client::JsonRpcClient;
+use std::io::{self, Write};
+
+pub fn input(query: &str) -> io::Result<String> {
+    print!("{}", query);
+    io::stdout().flush()?;
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(input.trim().to_owned())
+}
+
+pub fn select<S, F>(print_msg: fn(), query: &str, chk: F) -> io::Result<S>
+where
+    F: Fn(&str) -> Option<S>,
+{
+    loop {
+        print_msg();
+        for _ in 1..=5 {
+            let selection = input(query)?;
+            if let Some(selection) = chk(selection.to_lowercase().as_str()) {
+                return Ok(selection);
+            }
+            println!("\x1b[31m(i)\x1b[0m invalid selection, retry..");
+        }
+    }
+}
+
+pub fn select_network() -> io::Result<JsonRpcClient> {
+    println!("========[Network Selection]========");
+    let network = select(
+        || {
+            println!(" [1] mainnet \x1b[38;5;244m(alias: m, main)\x1b[0m");
+            println!(" [2] testnet \x1b[38;5;244m(alias: t, test)\x1b[0m");
+            println!(" [3] custom  \x1b[38;5;244m(alias:       c)\x1b[0m");
+        },
+        "\x1b[33m(enter a selection)\x1b[0m> ",
+        |selection| match (selection, selection.parse()) {
+            ("m" | "main" | "mainnet", _) | (_, Ok(1)) => Some("mainnet"),
+            ("t" | "test" | "testnet", _) | (_, Ok(2)) => Some("testnet"),
+            ("c" | "custom", _) | (_, Ok(3)) => Some("custom"),
+            _ => None,
+        },
+    )?;
+    let network_url = if network != "custom" {
+        let archival = select(
+            || (),
+            "Should we connect to an archival node? [y/N] ",
+            |selection| match selection {
+                "" | "n" | "no" => Some(false),
+                "y" | "yes" => Some(true),
+                _ => None,
+            },
+        )?;
+        println!(
+            "\x1b[32m(i)\x1b[0m Connected to the [{}] network{}",
+            network,
+            if archival {
+                " (via an archival node)"
+            } else {
+                ""
+            }
+        );
+        format!(
+            "https://{archival}rpc.{network}.near.org",
+            archival = if archival { "archival-" } else { "" },
+            network = network
+        )
+    } else {
+        loop {
+            let url = input("Enter the RPC Server Address: ")?;
+            if let Err(err) = url.parse::<reqwest::Url>() {
+                println!("\x1b[31m(i)\x1b[0m invalid url ({}), retry..", err);
+                continue;
+            }
+            break url;
+        }
+    };
+    println!("===================================");
+
+    Ok(JsonRpcClient::connect(network_url))
+}
+
+fn main() {
+    panic!("not a binary")
+}

--- a/accounts/src/accounts.rs
+++ b/accounts/src/accounts.rs
@@ -4,17 +4,8 @@ use near_primitives::types::{AccountId, Balance, BlockReference, Finality};
 use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest};
 use near_jsonrpc_primitives::types::query::{RpcQueryResponse, QueryResponseKind};
 use near_primitives::account::AccessKey;
-//use near_jsonrpc_client::errors::JsonRpcError;
-//use near_jsonrpc_primitives::types::transactions::RpcTransactionError;
-
-
-//items from traits can only be used if the trait is in scope
-// can we change it somehow with better crate design?
 use providers::Provider;
-//use providers::JsonRpcProvider;
-
 use std::sync::Arc;
-
 
 pub struct Account {
     pub account_id: AccountId,
@@ -78,7 +69,7 @@ impl Account {
 }
 
 
-//To-do
+// TODO
 //JS reference for 
 // protected async signTransaction(receiverId: string, actions: Action[]): Promise<[Uint8Array, SignedTransaction]> {
 //     const accessKeyInfo = await this.findAccessKey(receiverId, actions);
@@ -95,54 +86,3 @@ impl Account {
 //         receiverId, nonce, actions, baseDecode(blockHash), this.connection.signer, this.accountId, this.connection.networkId
 //     );
 // }
-
-#[cfg(test)]
-mod tests {
-
-    use providers::JsonRpcProvider;
-    use std::sync::Arc;
-    use near_crypto::InMemorySigner;
-    use near_primitives::types::Balance;
-    use near_crypto::{Signer, PublicKey};
-    use crate::Account;
-    mod utils;
-    use std::io::{self, Write};
-    
-    #[tokio::test]
-    async fn test_create_account() {
-        
-        let signer_account_id = input("Enter the signer Account ID: ")?.parse()?;
-        let signer_secret_key = input("Enter the signer's private key: ")?.parse()?;
-        let new_account_id = input("Enter the signer's private key: ")?.parse()?;
-        //let new_account_id = "newaccount.testnet".parse().unwrap();
-        //let private_key = "ed25519:3tNQ8Nt6y9m7Kq3VkaQH8k2L7yD3xq6CJXbwz1tEPVZD".parse().unwrap(); // Example private key
-        let signer = InMemorySigner::from_secret_key(signer_account_id, signer_secret_key);
-        // Amount to transfer to the new account
-        let amount: Balance = 10_000_000_000_000_000_000_000; // Example amount in yoctoNEAR
-
-        // Public key for the new account (normally generated but for the test we can use a fixed one)
-        
-        //Create a keypaid using near_crypto
-        let new_key_pair = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
-        //let public_key: PublicKey = PublicKey::from_str("ed25519:8LXEySyBYewiTTLxjfF1TKDsxxxxxxxxxxxxxx").unwrap();
-
-        //let provider = Arc::new(MockProvider);
-        let provider = JsonRpcProvider::new("https://rpc.testnet.near.org");
-        let signer = Arc::new(signer);
-
-        let account = Account::new(signer_account_id, signer, provider);
-
-        // Call create_account
-        let result = account.create_account(new_account_id, new_key_pair.public_key(), amount).await;
-
-        assert!(result.is_ok());
-    }
-
-    pub fn input(query: &str) -> io::Result<String> {
-        print!("{}", query);
-        io::stdout().flush()?;
-        let mut input = String::new();
-        io::stdin().read_line(&mut input)?;
-        Ok(input.trim().to_owned())
-    }
-}

--- a/accounts/src/accounts.rs
+++ b/accounts/src/accounts.rs
@@ -1,12 +1,17 @@
 use transactions::TransactionBuilder;
 use near_crypto::{Signer, PublicKey};
 use near_primitives::types::{AccountId, Balance, BlockReference, Finality};
-use near_primitives::views::FinalExecutionOutcomeView;
+use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest};
+use near_jsonrpc_primitives::types::query::{RpcQueryResponse, QueryResponseKind};
+use near_primitives::account::AccessKey;
+//use near_jsonrpc_client::errors::JsonRpcError;
+//use near_jsonrpc_primitives::types::transactions::RpcTransactionError;
 
 
 //items from traits can only be used if the trait is in scope
 // can we change it somehow with better crate design?
 use providers::Provider;
+//use providers::JsonRpcProvider;
 
 use std::sync::Arc;
 
@@ -22,33 +27,51 @@ impl Account {
         Self { account_id, signer, provider }
     }
 
+    // Function to fetch the current nonce for an account's access key
+    pub async fn fetch_nonce(&self, account_id: &AccountId, public_key: &PublicKey) -> Result<u64, Box<dyn std::error::Error>> {
+        
+        let query_request = QueryRequest::ViewAccessKey {
+            account_id: account_id.clone(),
+            public_key: public_key.clone(),
+        };
+
+        // Send the query to the NEAR blockchain
+        let response: RpcQueryResponse = self.provider.query(query_request).await?;
+
+        // Extract the access key view from the response
+        if let QueryResponseKind::AccessKey(access_key_view) = response.kind {
+            Ok(access_key_view.nonce)
+        } else {
+            Err("Unexpected response kind".into())
+        }
+    }
+
     pub async fn create_account(&self, new_account_id: AccountId, public_key: PublicKey, amount: Balance) -> Result<FinalExecutionOutcomeView, Box<dyn std::error::Error>> {
         //Look into the whole access key thingy. We need it anyway but it also helps with nonce.
         // Fetch the current nonce for the signer account and latest block hash
-        let nonce = self.provider.fetch_nonce(&self.account_id).await?;
+        let nonce = self.fetch_nonce(&self.account_id, &self.signer.public_key()).await?;
         
-        //Implement provider.block for this.
+        //Block hash
         let block_reference = BlockReference::Finality(Finality::Final);
-        let block_hash = self.provider.block(block_reference).await?;
+        let block = self.provider.block(block_reference).await?;
+        let block_hash = block.header.hash;
 
         // Use TransactionBuilder to construct the transaction
         let signed_tx = TransactionBuilder::new(
             self.account_id.clone(), 
             self.signer.public_key(), 
-            nonce, 
             new_account_id.clone(), 
+            nonce+1, 
             block_hash)
             .create_account()
             .transfer(amount)
             .add_key(public_key, AccessKey::full_access())
-            .build();
+            //.build()
             .signTransaction(&*self.signer); // Sign the transaction
 
-        // Sign the transaction
-        //let signed_tx = self.signer.sign_transaction(&transaction).await?;
-
         // Send the transaction
-        self.provider.send_transaction(&signed_tx).await
+        let transaction_result = self.provider.send_transaction(signed_tx).await?;
+        Ok(transaction_result)
     }
 
     // Implement other account methods using TransactionBuilder...
@@ -72,3 +95,54 @@ impl Account {
 //         receiverId, nonce, actions, baseDecode(blockHash), this.connection.signer, this.accountId, this.connection.networkId
 //     );
 // }
+
+#[cfg(test)]
+mod tests {
+
+    use providers::JsonRpcProvider;
+    use std::sync::Arc;
+    use near_crypto::InMemorySigner;
+    use near_primitives::types::Balance;
+    use near_crypto::{Signer, PublicKey};
+    use crate::Account;
+    mod utils;
+    use std::io::{self, Write};
+    
+    #[tokio::test]
+    async fn test_create_account() {
+        
+        let signer_account_id = input("Enter the signer Account ID: ")?.parse()?;
+        let signer_secret_key = input("Enter the signer's private key: ")?.parse()?;
+        let new_account_id = input("Enter the signer's private key: ")?.parse()?;
+        //let new_account_id = "newaccount.testnet".parse().unwrap();
+        //let private_key = "ed25519:3tNQ8Nt6y9m7Kq3VkaQH8k2L7yD3xq6CJXbwz1tEPVZD".parse().unwrap(); // Example private key
+        let signer = InMemorySigner::from_secret_key(signer_account_id, signer_secret_key);
+        // Amount to transfer to the new account
+        let amount: Balance = 10_000_000_000_000_000_000_000; // Example amount in yoctoNEAR
+
+        // Public key for the new account (normally generated but for the test we can use a fixed one)
+        
+        //Create a keypaid using near_crypto
+        let new_key_pair = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
+        //let public_key: PublicKey = PublicKey::from_str("ed25519:8LXEySyBYewiTTLxjfF1TKDsxxxxxxxxxxxxxx").unwrap();
+
+        //let provider = Arc::new(MockProvider);
+        let provider = JsonRpcProvider::new("https://rpc.testnet.near.org");
+        let signer = Arc::new(signer);
+
+        let account = Account::new(signer_account_id, signer, provider);
+
+        // Call create_account
+        let result = account.create_account(new_account_id, new_key_pair.public_key(), amount).await;
+
+        assert!(result.is_ok());
+    }
+
+    pub fn input(query: &str) -> io::Result<String> {
+        print!("{}", query);
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        Ok(input.trim().to_owned())
+    }
+}

--- a/accounts/src/lib.rs
+++ b/accounts/src/lib.rs
@@ -1,4 +1,3 @@
-
 pub use crate::connection::Connection;
 pub use crate::accounts::Account;
 

--- a/providers/src/json_rpc_provider.rs
+++ b/providers/src/json_rpc_provider.rs
@@ -9,7 +9,7 @@ use near_jsonrpc_primitives::types::transactions::RpcTransactionError;
 use near_primitives::hash::CryptoHash;
 use near_jsonrpc_primitives::types::transactions::TransactionInfo;
 use near_jsonrpc_primitives::types::chunks::{RpcChunkError,  ChunkReference};
-use near_primitives::types::{BlockReference, EpochReference};
+use near_primitives::types::{BlockReference, EpochReference, Finality};
 use near_jsonrpc_primitives::types::blocks::RpcBlockError;
 use near_jsonrpc_primitives::types::validator::RpcValidatorError;
 
@@ -100,6 +100,23 @@ async fn test_status() {
             // For example, checking if the chain_id matches testnet
             //println!("Received response: {:?}", response);
             assert!(response.chain_id.contains("testnet"), "Chain ID should contain 'testnet'");
+        }
+        Err(e) => panic!("Status request failed with {:?}", e),
+    }
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn test_block() {
+    let provider = JsonRpcProvider::new("https://rpc.testnet.near.org");
+    let block_reference = BlockReference::Finality(Finality::Final);
+    //let block_hash = provider.block(block_reference).await?;
+    match provider.block(block_reference).await {
+        Ok(response) => {
+            // Perform checks on the response
+            // For example, checking if the chain_id matches testnet
+            println!("Received response: {:?}", response);
+            //assert!(response.chain_id.contains("testnet"), "Chain ID should contain 'testnet'");
         }
         Err(e) => panic!("Status request failed with {:?}", e),
     }

--- a/providers/src/provider.rs
+++ b/providers/src/provider.rs
@@ -14,7 +14,7 @@ use near_jsonrpc_primitives::types::blocks::RpcBlockError;
 use near_jsonrpc_primitives::types::validator::RpcValidatorError;
 use near_jsonrpc_primitives::types::query::{RpcQueryError, RpcQueryRequest, RpcQueryResponse, QueryResponseKind};
 
-// To-do
+// @To-do
 // Implement a Conversion From JsonRpcError<RpcStatusError> to RpcStatusError: If you need to keep the RpcStatusError as your function's error type for consistency or other reasons, you can implement a conversion using the From trait or manually handle the conversion in each call.
 
 // Example of Manual Error Handling

--- a/providers/src/provider.rs
+++ b/providers/src/provider.rs
@@ -12,7 +12,7 @@ use near_jsonrpc_primitives::types::transactions::TransactionInfo;
 use near_jsonrpc_primitives::types::chunks::{RpcChunkError,  ChunkReference};
 use near_jsonrpc_primitives::types::blocks::RpcBlockError;
 use near_jsonrpc_primitives::types::validator::RpcValidatorError;
-
+use near_jsonrpc_primitives::types::query::{RpcQueryError, RpcQueryRequest, RpcQueryResponse, QueryResponseKind};
 
 // To-do
 // Implement a Conversion From JsonRpcError<RpcStatusError> to RpcStatusError: If you need to keep the RpcStatusError as your function's error type for consistency or other reasons, you can implement a conversion using the From trait or manually handle the conversion in each call.
@@ -43,4 +43,7 @@ pub trait Provider {
     async fn chunk(&self, chunk_reference: ChunkReference) -> Result<ChunkView, JsonRpcError<RpcChunkError>>;
     async fn block(&self, block_reference: BlockReference) -> Result<BlockView, JsonRpcError<RpcBlockError>>;
     async fn validators(&self, epoch_reference: EpochReference) -> Result<EpochValidatorInfo, JsonRpcError<RpcValidatorError>>;
+    async fn query<T: QueryResponseKind>(&self, params: RpcQueryRequest) -> Result<T, JsonRpcError<RpcQueryError>>;
+    //chat gpt version
+    //async fn query<T: QueryResponseKind>(&self, params: RpcQueryRequest) -> Result<T, Box<dyn std::error::Error>>;
 }

--- a/providers/src/provider.rs
+++ b/providers/src/provider.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use near_jsonrpc_client::methods::status::RpcStatusResponse;
 use near_jsonrpc_primitives::types::status::RpcStatusError;
-use near_primitives::views::{FinalExecutionOutcomeView, ChunkView, BlockView, EpochValidatorInfo};
+use near_primitives::views::{FinalExecutionOutcomeView, ChunkView, BlockView, EpochValidatorInfo, QueryRequest};
 use near_primitives::transaction::SignedTransaction;
 use near_jsonrpc_primitives::types::transactions::RpcTransactionError;
 use near_jsonrpc_client::errors::JsonRpcError;
@@ -43,7 +43,5 @@ pub trait Provider {
     async fn chunk(&self, chunk_reference: ChunkReference) -> Result<ChunkView, JsonRpcError<RpcChunkError>>;
     async fn block(&self, block_reference: BlockReference) -> Result<BlockView, JsonRpcError<RpcBlockError>>;
     async fn validators(&self, epoch_reference: EpochReference) -> Result<EpochValidatorInfo, JsonRpcError<RpcValidatorError>>;
-    async fn query<T: QueryResponseKind>(&self, params: RpcQueryRequest) -> Result<T, JsonRpcError<RpcQueryError>>;
-    //chat gpt version
-    //async fn query<T: QueryResponseKind>(&self, params: RpcQueryRequest) -> Result<T, Box<dyn std::error::Error>>;
+    async fn query(&self, request: QueryRequest) -> Result<RpcQueryResponse, JsonRpcError<RpcQueryError>>;
 }

--- a/transactions/src/transaction_builder.rs
+++ b/transactions/src/transaction_builder.rs
@@ -24,8 +24,8 @@ impl TransactionBuilder {
             transaction: Transaction {
                 signer_id,
                 public_key,
-                nonce,
                 receiver_id,
+                nonce,
                 block_hash,
                 actions: Vec::new(), // Initialize the actions vector here
             },


### PR DESCRIPTION
- Added query request to support finding nonce for an access key. Query request let's you do general queries to chain.
- Completed create_account function.
- Created an example for create_account
- With this merge we have an end to end working flow. Create a transaction, sign it, send it to chain. 