### PR TITLE
Implement delete_key and get_account balance fro Accounts crate

### DIFF
--- a/near-accounts/Cargo.toml
+++ b/near-accounts/Cargo.toml
@@ -14,6 +14,7 @@ near-jsonrpc-primitives = "0.20.1"
 near-jsonrpc-client = "0.8.0"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1.0.85"
+num-bigint = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/near-accounts/examples/account_balance.rs
+++ b/near-accounts/examples/account_balance.rs
@@ -1,17 +1,17 @@
 use near_providers::JsonRpcProvider;
 use std::sync::Arc;
-use near_accounts::accounts::{get_access_key};
 use near_primitives::types::AccountId;
+use near_accounts::accounts::{get_account_balance};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
-    let account_id: AccountId = "near-api-rs.testnet".parse::<AccountId>()?;
+    let account_id: AccountId = "contract.near-api-rs.testnet".parse::<AccountId>()?;
 
     let provider = Arc::new(JsonRpcProvider::new("https://rpc.testnet.near.org"));
 
-    let result = get_access_key(provider, account_id).await;
+    let result = get_account_balance(provider, account_id).await;
 
     println!("response: {:#?}", result);
 

--- a/near-accounts/examples/delete_key.rs
+++ b/near-accounts/examples/delete_key.rs
@@ -1,0 +1,29 @@
+use near_providers::JsonRpcProvider;
+use std::sync::Arc;
+use near_crypto::{InMemorySigner, PublicKey};
+use near_accounts::Account;
+mod utils;
+use near_primitives::types::AccountId;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let signer_account_id: AccountId = utils::input("Enter the signer Account ID: ")?.parse()?;
+    let signer_secret_key = utils::input("Enter the signer's private key: ")?.parse()?;
+    let signer = InMemorySigner::from_secret_key(signer_account_id.clone(), signer_secret_key);
+        
+    let provider = Arc::new(JsonRpcProvider::new("https://rpc.testnet.near.org"));
+    let signer = Arc::new(signer);
+
+    let account = Account::new(signer_account_id, signer, provider);
+
+    let public_key: PublicKey = "ed25519:EohEtHT8Dt8jURC3DcJ661hWCx6ExPRtDV82FpT4jfNB".parse::<PublicKey>()?;
+    
+    let result = account.delete_key(public_key).await;
+
+
+    println!("response: {:#?}", result);
+
+    Ok(())
+}

--- a/near-providers/Cargo.toml
+++ b/near-providers/Cargo.toml
@@ -13,7 +13,7 @@ near-jsonrpc-primitives = "0.20.1"
 async-trait = "0.1.50"
 serde_json = "1.0.85"
 near-crypto = "0.20.1"
-
+near-chain-configs = "0.20.0"
 
 
 [dev-dependencies]

--- a/near-providers/src/json_rpc_provider.rs
+++ b/near-providers/src/json_rpc_provider.rs
@@ -13,6 +13,8 @@ use near_primitives::types::{BlockReference, EpochReference, Finality};
 use near_jsonrpc_primitives::types::blocks::RpcBlockError;
 use near_jsonrpc_primitives::types::validator::RpcValidatorError;
 use near_jsonrpc_primitives::types::query::{RpcQueryError, RpcQueryRequest, RpcQueryResponse};
+use near_jsonrpc_primitives::types::config::{RpcProtocolConfigError};
+use near_chain_configs::ProtocolConfigView;
 
 
 use crate::Provider;
@@ -91,6 +93,14 @@ impl Provider for JsonRpcProvider {
             block_reference,
         };
 
+        let response = self.client.call(request).await?;
+        Ok(response)
+    }
+
+    async fn experimental_protocol_config(&self, block_reference: BlockReference) -> Result<ProtocolConfigView, JsonRpcError<RpcProtocolConfigError>> {
+        let request = methods::EXPERIMENTAL_protocol_config::RpcProtocolConfigRequest {
+            block_reference,
+        };
         let response = self.client.call(request).await?;
         Ok(response)
     }

--- a/near-providers/src/provider.rs
+++ b/near-providers/src/provider.rs
@@ -13,6 +13,8 @@ use near_jsonrpc_primitives::types::chunks::{RpcChunkError,  ChunkReference};
 use near_jsonrpc_primitives::types::blocks::RpcBlockError;
 use near_jsonrpc_primitives::types::validator::RpcValidatorError;
 use near_jsonrpc_primitives::types::query::{RpcQueryError, RpcQueryResponse};
+use near_jsonrpc_primitives::types::config::{RpcProtocolConfigError};
+use near_chain_configs::ProtocolConfigView;
 
 
 #[async_trait]
@@ -25,4 +27,5 @@ pub trait Provider {
     async fn block(&self, block_reference: BlockReference) -> Result<BlockView, JsonRpcError<RpcBlockError>>;
     async fn validators(&self, epoch_reference: EpochReference) -> Result<EpochValidatorInfo, JsonRpcError<RpcValidatorError>>;
     async fn query(&self, request: QueryRequest) -> Result<RpcQueryResponse, JsonRpcError<RpcQueryError>>;
+    async fn experimental_protocol_config(&self, block_reference: BlockReference) -> Result<ProtocolConfigView, JsonRpcError<RpcProtocolConfigError>>;
 }


### PR DESCRIPTION
- Added `delete_key`, addressing #16 
- Added `get_account_balance`, addressing #20
- Added `experimental_protocol_config` method to the JSON rpc provider to support account balance function.
- Refactored `add_key` to use `get_transaction_builder`